### PR TITLE
update snakemake8/snakemake_cluster

### DIFF
--- a/PRIME_cluster/snakemake8/snakemake_cluster
+++ b/PRIME_cluster/snakemake8/snakemake_cluster
@@ -1,1 +1,1 @@
-snakemake --rerun-incomplete -call all --latency-wait 100 --cluster-generic-submit-cmd "sbatch --parsable -p q36, q64 -n 1 --cpus-per-task {threads} --mem {resources.mem_mb}" "$@"
+snakemake --rerun-incomplete -call all --latency-wait 100 --executor cluster-generic --cluster-generic-submit-cmd "sbatch --parsable -p q36,q64 -n 1 --cpus-per-task {threads} --mem {resources.mem_mb}" "$@"


### PR DESCRIPTION
I tested the snakemake_cluster for snakemake8 and got an error, because q36 and q64 were separated by a space. I also had the problem, that the slurm queue was not used until I added "--executor cluster-generic"